### PR TITLE
Add spin buttons to numeric inputs

### DIFF
--- a/Client/Pages/Game.razor
+++ b/Client/Pages/Game.razor
@@ -982,43 +982,49 @@
                                 var shariahBonds = _gameState.AvailableBondRates.Where(r => r.IsShariah).ToList();
                             }
 
-                            @if (convBonds.Any())
-                            {
-                                <div class="bond-group-header">🏦 @GetText("Konvensional", "Konvensional", "Conventional", "Conventional")</div>
-                                <div class="bond-rates">
-                                    @foreach (var rate in convBonds)
-                                    {
-                                        <div class="bond-rate-card @(_selectedBondType == rate.BondType ? "selected" : "")"
-                                             @onclick="() => _selectedBondType = rate.BondType">
-                                            <span class="bond-type">@rate.BondType @(!string.IsNullOrEmpty(rate.SeriesName) ? $"({rate.SeriesName})" : "")</span>
-                                            <span class="bond-period">@rate.PeriodName</span>
-                                            <span class="bond-coupon">@((rate.CouponRate * 100).ToString("F2"))% @GetText("kupon", "kupon", "coupon", "coupon")</span>
-                                            <span class="min-invest">Min: Rp @rate.MinimumInvestment.ToString("N0")</span>
-                                        </div>
-                                    }
-                                </div>
-                            }
-
-                            @if (shariahBonds.Any())
-                            {
-                                <div class="bond-group-header">☪️ @GetText("Syariah (Sukuk)", "Syariah (Sukuk)", "Shariah (Sukuk)", "Shariah (Sukuk)")</div>
-                                <div class="bond-rates">
-                                    @foreach (var rate in shariahBonds)
-                                    {
-                                        <div class="bond-rate-card shariah @(_selectedBondType == rate.BondType ? "selected" : "")"
-                                             @onclick="() => _selectedBondType = rate.BondType">
-                                            <span class="bond-type">@rate.BondType @(!string.IsNullOrEmpty(rate.SeriesName) ? $"({rate.SeriesName})" : "")</span>
-                                            <span class="bond-period">@rate.PeriodName</span>
-                                            <span class="bond-coupon">@((rate.CouponRate * 100).ToString("F2"))% @GetText("kupon", "kupon", "coupon", "coupon")</span>
-                                            @if (!string.IsNullOrEmpty(rate.AkadType))
+                            <div class="bond-groups-row">
+                                @if (convBonds.Any())
+                                {
+                                    <div class="bond-group">
+                                        <div class="bond-group-header">🏦 @GetText("Konvensional", "Konvensional", "Conventional", "Conventional")</div>
+                                        <div class="bond-rates">
+                                            @foreach (var rate in convBonds)
                                             {
-                                                <span class="akad-info">@rate.AkadType</span>
+                                                <div class="bond-rate-card @(_selectedBondType == rate.BondType ? "selected" : "")"
+                                                     @onclick="() => _selectedBondType = rate.BondType">
+                                                    <span class="bond-type">@rate.BondType @(!string.IsNullOrEmpty(rate.SeriesName) ? $"({rate.SeriesName})" : "")</span>
+                                                    <span class="bond-period">@rate.PeriodName</span>
+                                                    <span class="bond-coupon">@((rate.CouponRate * 100).ToString("F2"))% @GetText("kupon", "kupon", "coupon", "coupon")</span>
+                                                    <span class="min-invest">Min: Rp @rate.MinimumInvestment.ToString("N0")</span>
+                                                </div>
                                             }
-                                            <span class="min-invest">Min: Rp @rate.MinimumInvestment.ToString("N0")</span>
                                         </div>
-                                    }
-                                </div>
-                            }
+                                    </div>
+                                }
+
+                                @if (shariahBonds.Any())
+                                {
+                                    <div class="bond-group">
+                                        <div class="bond-group-header">☪️ @GetText("Syariah (Sukuk)", "Syariah (Sukuk)", "Shariah (Sukuk)", "Shariah (Sukuk)")</div>
+                                        <div class="bond-rates">
+                                            @foreach (var rate in shariahBonds)
+                                            {
+                                                <div class="bond-rate-card shariah @(_selectedBondType == rate.BondType ? "selected" : "")"
+                                                     @onclick="() => _selectedBondType = rate.BondType">
+                                                    <span class="bond-type">@rate.BondType @(!string.IsNullOrEmpty(rate.SeriesName) ? $"({rate.SeriesName})" : "")</span>
+                                                    <span class="bond-period">@rate.PeriodName</span>
+                                                    <span class="bond-coupon">@((rate.CouponRate * 100).ToString("F2"))% @GetText("kupon", "kupon", "coupon", "coupon")</span>
+                                                    @if (!string.IsNullOrEmpty(rate.AkadType))
+                                                    {
+                                                        <span class="akad-info">@rate.AkadType</span>
+                                                    }
+                                                    <span class="min-invest">Min: Rp @rate.MinimumInvestment.ToString("N0")</span>
+                                                </div>
+                                            }
+                                        </div>
+                                    </div>
+                                }
+                            </div>
 
                             <div class="bond-amount-input">
                                 <div class="numeric-spin-group">

--- a/Client/wwwroot/css/app.css
+++ b/Client/wwwroot/css/app.css
@@ -2010,7 +2010,7 @@ html, body {
     font-family: 'Cormorant Garamond', 'Georgia', serif;
     font-size: 1.3rem;
     font-weight: 600;
-    border: 3px solid var(--stroke-color);
+    border: 2px solid var(--stroke-color);
     border-radius: 6px;
     background: white;
     color: var(--text-dark);
@@ -4316,9 +4316,21 @@ html, body {
     content: '';
 }
 
+.bond-groups-row {
+    display: flex;
+    flex-direction: row;
+    gap: 0.8rem;
+    align-items: flex-start;
+}
+
+.bond-group {
+    flex: 1;
+    min-width: 0;
+}
+
 .bond-rates {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
     gap: 0.6rem;
 }
 
@@ -4395,7 +4407,7 @@ html, body {
     font-family: 'Cormorant Garamond', 'Georgia', serif;
     font-size: 1.3rem;
     font-weight: 600;
-    border: 3px solid var(--stroke-color);
+    border: 2px solid var(--stroke-color);
     border-radius: 6px;
     background: white;
     color: var(--text-dark);
@@ -4872,6 +4884,10 @@ html, body {
 
     .bond-rates {
         grid-template-columns: 1fr;
+    }
+
+    .bond-groups-row {
+        flex-direction: column;
     }
 }
 
@@ -5828,6 +5844,7 @@ html, body {
     padding: 0.8rem;
     flex: 1;
     min-width: 120px;
+    overflow: hidden;
     box-shadow: 2px 2px 6px rgba(0,0,0,0.1);
     transition: all 0.2s ease;
 }
@@ -5897,9 +5914,15 @@ html, body {
 .crowdfunding-buy-controls {
     display: flex;
     flex-direction: row;
-    gap: 0.5rem;
+    gap: 0.4rem;
     align-items: stretch;
     margin-top: 0.5rem;
+}
+
+.crowdfunding-buy-controls .numeric-spin-group,
+.crypto-coin-card .crypto-buy-controls .numeric-spin-group {
+    flex: 1;
+    min-width: 0;
 }
 
 .cf-input {
@@ -5916,10 +5939,10 @@ html, body {
 }
 
 .cf-buy-btn {
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 0.6rem;
     font-size: 0.8rem;
     font-weight: 700;
-    min-width: 70px;
+    flex-shrink: 0;
     border-radius: 6px;
     white-space: nowrap;
     background: linear-gradient(135deg, var(--ayam-brown), var(--ayam-brown-light));
@@ -6291,19 +6314,16 @@ html, body {
         max-width: 100%;
     }
 
-    .crypto-coin-card .crypto-buy-controls,
-    .crowdfunding-buy-controls {
+    .crypto-coin-card .crypto-buy-controls {
         flex-direction: row;
     }
 
-    .crypto-coin-card .crypto-input,
-    .cf-input {
+    .crypto-coin-card .crypto-input {
         flex: 1;
         min-width: 0;
     }
 
-    .crypto-coin-card .crypto-buy-btn,
-    .cf-buy-btn {
+    .crypto-coin-card .crypto-buy-btn {
         width: auto;
         flex-shrink: 0;
     }


### PR DESCRIPTION
## Summary
- Adds **−/+** spin buttons flanking every numeric input field (Savings, Deposito, Bond, Crypto, Crowdfunding)
- Each button increments/decrements by the placeholder step value:
  - **Rp 1.000.000** for Savings, Deposito, Bond, Crypto
  - **Rp 100.000** for Crowdfunding
- Decrement button is disabled when the value reaches 0 (prevents negative amounts)
- Styled with dark-theme variant for the Crypto section
- Touch-friendly sizing (44px min tap target) and responsive scaling for mobile

## UX Rationale
On mobile, typing exact formatted numbers (e.g. "5.000.000") is friction-heavy. Spin buttons let users quickly tap to common round amounts — the most frequent interaction pattern in the game. Users can still type custom amounts directly in the input field.

## Test plan
- [ ] Verify all 5 input types show − and + buttons
- [ ] Tap + multiple times — value increases by step each time
- [ ] Tap − — value decreases, stops at 0 (button disabled)
- [ ] Type a custom amount — still works as before
- [ ] Check mobile layout (buttons don't overflow or wrap awkwardly)
- [ ] Check crypto inputs use the dark-themed spin buttons

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)