### PR TITLE
#27 - Fix multiplayer asset unlock not showing in market

### DIFF
--- a/Server/Hubs/GameHub.cs
+++ b/Server/Hubs/GameHub.cs
@@ -254,6 +254,16 @@ public class GameHub : Hub
             // All players dismissed their intro popups — resume all sessions
             _gameEngine.ResumeAllInRoom(room.RoomCode);
             _roomManager.ResetUnlockReady(room.RoomCode);
+
+            // Send updated game state to each player so unlocked assets are reflected in the UI
+            var sessions = _gameEngine.GetRoomSessions(room.RoomCode);
+            foreach (var session in sessions)
+            {
+                var gameState = session.ToGameState();
+                gameState.PlayerSummaries = GetPlayerSummaries(room.RoomCode);
+                await Clients.Client(session.ConnectionId).SendAsync("GameStateUpdated", gameState);
+            }
+
             // Send updated room (all IsUnlockReady=false) to host so dashboard resets
             await Clients.Client(room.HostConnectionId).SendAsync("RoomUpdated", room);
             await Clients.Group(room.RoomCode).SendAsync("UnlockComplete");
@@ -267,6 +277,16 @@ public class GameHub : Hub
 
         _gameEngine.ResumeAllInRoom(room.RoomCode);
         _roomManager.ResetUnlockReady(room.RoomCode);
+
+        // Send updated game state to each player so unlocked assets are reflected in the UI
+        var sessions = _gameEngine.GetRoomSessions(room.RoomCode);
+        foreach (var session in sessions)
+        {
+            var gameState = session.ToGameState();
+            gameState.PlayerSummaries = GetPlayerSummaries(room.RoomCode);
+            await Clients.Client(session.ConnectionId).SendAsync("GameStateUpdated", gameState);
+        }
+
         // Send updated room (all IsUnlockReady=false) to host so dashboard resets
         await Clients.Client(room.HostConnectionId).SendAsync("RoomUpdated", room);
         await Clients.Group(room.RoomCode).SendAsync("UnlockComplete");

--- a/Server/Services/GameEngine.cs
+++ b/Server/Services/GameEngine.cs
@@ -1022,6 +1022,10 @@ public class GameEngine
                 ExpectedReturn = p.ExpectedReturn, RiskLevel = p.RiskLevel, IsActive = true
             }).ToList());
 
+            // Set per-session rates for game year 1
+            session.CurrentDepositoRates = RefreshDepositoRates(1);
+            session.CurrentBondRates = RefreshBondRates(1);
+
             session.UnlockedAssets.Add("tabungan");
             session.AddLogEntry(ageMode == AgeMode.Kids
                 ? "Selamat datang di Tjoean! Mari belajar investasi!"


### PR DESCRIPTION
## Summary
- **Bug**: In multiplayer, after closing the Certificate of Deposit (or any asset) introduction popup, the newly unlocked asset section was not displayed in the market
- **Root cause**: `SetUnlockReady()` and `HostForceResume()` in `GameHub.cs` resumed sessions and sent `UnlockComplete` but never sent an updated `GameState` to clients — so the client's `UnlockedAssets` list remained stale
- **Fix**: Send `GameStateUpdated` to each player after all unlock readiness is confirmed, ensuring the client UI reflects the newly unlocked assets

Closes #27

## Test plan
- [ ] Start a multiplayer game with 2+ players
- [ ] Advance to Month 6 (Deposito/Certificate of Deposit unlock)
- [ ] All players dismiss the intro popup
- [ ] Verify Deposito section appears in the market for all players
- [ ] Repeat with host using "Force Resume" button while some players haven't dismissed
- [ ] Verify Deposito section still appears for all players

🤖 Generated with [Claude Code](https://claude.com/claude-code)