### PR TITLE
#28 - Multiplayer player card improvements

### DIFF
--- a/Client/Pages/Game.razor
+++ b/Client/Pages/Game.razor
@@ -461,10 +461,21 @@
                 </div>
             </header>
 
+            @if (_hostGameFinished)
+            {
+                <div class="host-game-finished-banner">
+                    <span class="host-finished-icon">🏁</span>
+                    <span class="host-finished-text">@(_selectedLanguage == Language.Indonesian ? "Permainan Selesai!" : "Game Finished!")</span>
+                    <span class="host-finished-sub">@(_selectedLanguage == Language.Indonesian ? "Lihat ringkasan hasil pemain di bawah" : "View player result summaries below")</span>
+                </div>
+            }
+
             <main class="host-dashboard-main">
                 <!-- Left: Leaderboard -->
                 <section class="host-lb-panel">
-                    <h3>@(_selectedLanguage == Language.Indonesian ? "Papan Peringkat" : "Leaderboard")</h3>
+                    <h3>@(_hostGameFinished
+                        ? (_selectedLanguage == Language.Indonesian ? "Peringkat Akhir" : "Final Rankings")
+                        : (_selectedLanguage == Language.Indonesian ? "Papan Peringkat" : "Leaderboard"))</h3>
                     @if (_leaderboard != null && _leaderboard.Count > 0)
                     {
                         <div class="host-lb-list">
@@ -473,9 +484,11 @@
                                 <div class="host-lb-entry @(entry.IsBot ? "lb-bot" : "") @(!entry.IsConnected ? "lb-disconnected" : "")">
                                     <span class="lb-rank">#@entry.Rank</span>
                                     <span class="lb-name">@(entry.IsBot ? "Bot" : entry.PlayerName) @(!entry.IsConnected ? "⚡" : "")</span>
-                                    <span class="lb-worth">Rp @entry.NetWorth.ToString("N0")</span>
-                                    <span class="lb-profit @(entry.TotalProfit >= 0 ? "profit-pos" : "profit-neg")">
-                                        @(entry.TotalProfit >= 0 ? "+" : "")Rp @entry.TotalProfit.ToString("N0")
+                                    <span class="lb-worth-row">
+                                        <span class="lb-worth">Rp @entry.NetWorth.ToString("N0")</span>
+                                        <span class="lb-profit @(entry.TotalProfit >= 0 ? "profit-pos" : "profit-neg")">
+                                            @(entry.TotalProfit >= 0 ? "+" : "")Rp @entry.TotalProfit.ToString("N0")
+                                        </span>
                                     </span>
                                 </div>
                             }
@@ -486,7 +499,7 @@
                         <p class="host-lb-empty">@(_selectedLanguage == Language.Indonesian ? "Menunggu data..." : "Waiting for data...")</p>
                     }
 
-                    @if (_currentRoom != null)
+                    @if (_currentRoom != null && !_hostGameFinished)
                     {
                         <div class="host-unlock-ready-status">
                             <h4>@(_selectedLanguage == Language.Indonesian ? "Status Siap Lanjut" : "Unlock Ready Status")</h4>
@@ -518,7 +531,7 @@
                         <div class="host-portfolio-grid">
                             @foreach (var ps in _hostPortfolios)
                             {
-                                <div class="host-portfolio-card @(!ps.IsConnected ? "disconnected" : "")">
+                                <div class="host-portfolio-card @(!ps.IsConnected ? "disconnected" : "") @(_hostGameFinished ? "game-finished" : "")">
                                     <div class="portfolio-card-header">
                                         <span class="portfolio-player-name">@ps.PlayerName @(!ps.IsConnected ? "⚡" : "")</span>
                                         <span class="portfolio-networth">Rp @ps.NetWorth.ToString("N0")</span>
@@ -2500,6 +2513,7 @@
     private bool _isCreatingRoom;
     private bool _isJoiningRoom;
     private bool _isHost;
+    private bool _hostGameFinished;
     private bool _isReady;
     private List<LeaderboardEntry>? _leaderboard;
     private bool _showLeaderboard = false;           // collapsible leaderboard sidebar
@@ -2554,6 +2568,8 @@
         StateHasChanged();
     }
 
+    private string _lastPieDataHash = "";
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
@@ -2561,11 +2577,29 @@
             await ApplyTheme();
         }
 
-        // Render Chart.js pie charts for host dashboard
+        // Render Chart.js pie charts for host dashboard (skip if data unchanged to prevent blipping)
         if (_isHost && _multiplayerScreen == "host-dashboard" && _hostPortfolios.Count > 0)
         {
-            await RenderHostPieCharts();
+            var currentHash = GetPieDataHash();
+            if (currentHash != _lastPieDataHash)
+            {
+                _lastPieDataHash = currentHash;
+                await RenderHostPieCharts();
+            }
         }
+    }
+
+    private string GetPieDataHash()
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var ps in _hostPortfolios)
+        {
+            if (ps.PortfolioBreakdown == null) continue;
+            sb.Append(ps.ConnectionId);
+            foreach (var kvp in ps.PortfolioBreakdown)
+                sb.Append($"{kvp.Key}:{kvp.Value:F0}|");
+        }
+        return sb.ToString();
     }
 
     private async Task RenderHostPieCharts()
@@ -3944,6 +3978,7 @@
     private void HandleAllPlayersFinished(List<LeaderboardEntry> entries)
     {
         _leaderboard = entries;
+        _hostGameFinished = true;
         if (_gameState != null)
         {
             _gameState.AllPlayersFinished = true;

--- a/Client/Pages/Game.razor
+++ b/Client/Pages/Game.razor
@@ -531,22 +531,53 @@
                                             @(ps.TotalGainLoss >= 0 ? "+" : "")Rp @ps.TotalGainLoss.ToString("N0")
                                         </span>
                                     </div>
-                                    @if (ps.PortfolioBreakdown.Any())
-                                    {
-                                        <div class="host-pie-chart-container">
-                                            <canvas id="pie-@ps.ConnectionId" width="68" height="68" class="host-pie-canvas"></canvas>
-                                            <div class="host-pie-legend">
-                                                @foreach (var kvp in ps.PortfolioBreakdown)
-                                                {
-                                                    <div class="host-pie-legend-item">
-                                                        <span class="host-pie-dot" style="background: @GetBreakdownColor(kvp.Key)"></span>
-                                                        <span class="host-pie-label">@kvp.Key</span>
-                                                        <span class="host-pie-pct">@kvp.Value.ToString("F0")%</span>
-                                                    </div>
-                                                }
+                                    <div class="host-card-body">
+                                        @if (ps.PortfolioBreakdown.Any())
+                                        {
+                                            <div class="host-pie-chart-container">
+                                                <canvas id="pie-@ps.ConnectionId" width="68" height="68" class="host-pie-canvas"></canvas>
+                                                <div class="host-pie-legend">
+                                                    @foreach (var kvp in ps.PortfolioBreakdown)
+                                                    {
+                                                        <div class="host-pie-legend-item">
+                                                            <span class="host-pie-dot" style="background: @GetBreakdownColor(kvp.Key)"></span>
+                                                            <span class="host-pie-label">@kvp.Key</span>
+                                                            <span class="host-pie-pct">@kvp.Value.ToString("F0")%</span>
+                                                        </div>
+                                                    }
+                                                </div>
                                             </div>
+                                        }
+                                        <div class="host-financial-details">
+                                            @{
+                                                var details = new List<(string label, decimal value, bool isLoss)>
+                                                {
+                                                    ("Savings Int.", ps.SavingsInterestEarned, false),
+                                                    ("CD Interest", ps.DepositoInterestEarned, false),
+                                                    ("Bond Coupon", ps.BondCouponEarned, false),
+                                                    ("Dividends", ps.DividendEarned, false),
+                                                    ("Invest. P/L", ps.PortfolioGainLoss, ps.PortfolioGainLoss < 0),
+                                                    ("Crowdfund.", ps.CrowdfundingGainLoss, ps.CrowdfundingGainLoss < 0),
+                                                };
+                                            }
+                                            @foreach (var d in details.Where(d => d.value != 0))
+                                            {
+                                                <div class="fin-detail-row">
+                                                    <span class="fin-detail-label">@d.label</span>
+                                                    <span class="fin-detail-value @(d.isLoss ? "loss" : "gain")">
+                                                        @(d.value >= 0 ? "+" : "")Rp @d.value.ToString("N0")
+                                                    </span>
+                                                </div>
+                                            }
+                                            @if (ps.TotalEventCostPaid > 0)
+                                            {
+                                                <div class="fin-detail-row fin-detail-event">
+                                                    <span class="fin-detail-label">Events</span>
+                                                    <span class="fin-detail-value loss">-Rp @ps.TotalEventCostPaid.ToString("N0")</span>
+                                                </div>
+                                            }
                                         </div>
-                                    }
+                                    </div>
                                 </div>
                             }
                         </div>
@@ -3672,7 +3703,10 @@
         ["Savings"] = "#6BA5D7",
         ["Deposito"] = "#A88BC7",
         ["Bond"] = "#D4A854",
-        ["Portfolio"] = "#C97878",
+        ["Stocks"] = "#C97878",
+        ["Index"] = "#E8A87C",
+        ["Gold"] = "#E8D06C",
+        ["Crypto"] = "#7CC8E8",
         ["Crowdfunding"] = "#A08060"
     };
 

--- a/Client/wwwroot/css/app.css
+++ b/Client/wwwroot/css/app.css
@@ -8194,7 +8194,7 @@ html, body {
 
 .host-portfolio-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
     gap: 0.85rem;
 }
 
@@ -8306,6 +8306,62 @@ html, body {
     font-weight: 600;
     min-width: 30px;
     text-align: right;
+}
+
+/* Host card body: pie chart + financial details side by side */
+.host-card-body {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.host-card-body .host-pie-chart-container {
+    flex: 1;
+    min-width: 0;
+}
+
+.host-financial-details {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    border-left: 1px solid rgba(212, 200, 154, 0.1);
+    padding-left: 0.65rem;
+}
+
+.fin-detail-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.3rem;
+    font-size: 0.65rem;
+    line-height: 1.35;
+}
+
+.fin-detail-label {
+    color: #A69878;
+    white-space: nowrap;
+}
+
+.fin-detail-value {
+    font-weight: 600;
+    white-space: nowrap;
+    text-align: right;
+}
+
+.fin-detail-value.gain {
+    color: #A4CE95;
+}
+
+.fin-detail-value.loss {
+    color: #E88E8E;
+}
+
+.fin-detail-event {
+    margin-top: 0.15rem;
+    padding-top: 0.2rem;
+    border-top: 1px solid rgba(212, 200, 154, 0.08);
 }
 
 .portfolio-breakdown {
@@ -8445,7 +8501,7 @@ html, body {
     }
 
     .host-portfolio-grid {
-        grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
         gap: 0.65rem;
     }
 
@@ -8553,6 +8609,18 @@ html, body {
 
     .host-pie-legend-item {
         font-size: 0.68rem;
+    }
+
+    .host-card-body {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .host-financial-details {
+        border-left: none;
+        padding-left: 0;
+        border-top: 1px solid rgba(212, 200, 154, 0.08);
+        padding-top: 0.4rem;
     }
 
     .btn-host-action {

--- a/Client/wwwroot/css/app.css
+++ b/Client/wwwroot/css/app.css
@@ -8320,29 +8320,23 @@ html, body {
     text-align: right;
 }
 
-/* Host card body: pie chart + financial details side by side */
+/* Host card body: pie chart + financial details stacked */
 .host-card-body {
     display: flex;
-    gap: 0.75rem;
-    align-items: flex-start;
-    overflow: hidden;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 
 .host-card-body .host-pie-chart-container {
-    flex: 0 1 auto;
-    min-width: 0;
-    max-width: 55%;
+    width: 100%;
 }
 
 .host-financial-details {
-    flex: 1;
-    min-width: 0;
     display: flex;
     flex-direction: column;
     gap: 0.2rem;
-    border-left: 1px solid rgba(212, 200, 154, 0.1);
-    padding-left: 0.65rem;
-    overflow: hidden;
+    border-top: 1px solid rgba(212, 200, 154, 0.1);
+    padding-top: 0.4rem;
 }
 
 .fin-detail-row {
@@ -8672,17 +8666,6 @@ html, body {
         font-size: 0.68rem;
     }
 
-    .host-card-body {
-        flex-direction: column;
-        gap: 0.5rem;
-    }
-
-    .host-financial-details {
-        border-left: none;
-        padding-left: 0;
-        border-top: 1px solid rgba(212, 200, 154, 0.08);
-        padding-top: 0.4rem;
-    }
 
     .btn-host-action {
         padding: 0.3rem 0.5rem;

--- a/Client/wwwroot/css/app.css
+++ b/Client/wwwroot/css/app.css
@@ -8043,9 +8043,10 @@ html, body {
 }
 
 .host-lb-entry {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    display: grid;
+    grid-template-columns: 1.8rem 1fr;
+    grid-template-rows: auto auto;
+    gap: 0 0.4rem;
     padding: 0.55rem 0.65rem;
     border-radius: 8px;
     background: rgba(245, 240, 232, 0.06);
@@ -8069,26 +8070,37 @@ html, body {
 
 .lb-rank {
     font-weight: 700;
-    min-width: 1.8rem;
     color: #E8D89E;
+    grid-row: 1 / 3;
+    align-self: center;
 }
 
 .lb-name {
-    flex: 1;
     color: #E0D5C0;
-    white-space: nowrap;
+    font-weight: 600;
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    max-width: 100%;
+}
+
+.lb-worth-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    grid-column: 2;
+    min-width: 0;
 }
 
 .lb-worth {
-    font-weight: 600;
-    font-size: 0.75rem;
+    font-size: 0.72rem;
     color: #A4CE95;
+    font-weight: 600;
 }
 
 .lb-profit {
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     font-weight: 500;
 }
 
@@ -8313,11 +8325,13 @@ html, body {
     display: flex;
     gap: 0.75rem;
     align-items: flex-start;
+    overflow: hidden;
 }
 
 .host-card-body .host-pie-chart-container {
-    flex: 1;
+    flex: 0 1 auto;
     min-width: 0;
+    max-width: 55%;
 }
 
 .host-financial-details {
@@ -8328,6 +8342,7 @@ html, body {
     gap: 0.2rem;
     border-left: 1px solid rgba(212, 200, 154, 0.1);
     padding-left: 0.65rem;
+    overflow: hidden;
 }
 
 .fin-detail-row {
@@ -8337,17 +8352,21 @@ html, body {
     gap: 0.3rem;
     font-size: 0.65rem;
     line-height: 1.35;
+    min-width: 0;
 }
 
 .fin-detail-label {
     color: #A69878;
     white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .fin-detail-value {
     font-weight: 600;
     white-space: nowrap;
     text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .fin-detail-value.gain {
@@ -8362,6 +8381,39 @@ html, body {
     margin-top: 0.15rem;
     padding-top: 0.2rem;
     border-top: 1px solid rgba(212, 200, 154, 0.08);
+}
+
+/* Host Game Finished Banner */
+.host-game-finished-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1.5rem;
+    background: linear-gradient(135deg, rgba(139, 174, 121, 0.15) 0%, rgba(232, 216, 158, 0.12) 100%);
+    border-bottom: 2px solid rgba(139, 174, 121, 0.4);
+    flex-shrink: 0;
+}
+
+.host-finished-icon {
+    font-size: 1.5rem;
+}
+
+.host-finished-text {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #A4CE95;
+    letter-spacing: 0.04em;
+}
+
+.host-finished-sub {
+    font-size: 0.8rem;
+    color: #C4B898;
+}
+
+/* Host portfolio card game-finished state */
+.host-portfolio-card.game-finished {
+    border-color: rgba(139, 174, 121, 0.3);
 }
 
 .portfolio-breakdown {
@@ -8478,7 +8530,6 @@ html, body {
     }
 
     .host-lb-entry {
-        flex: 1 1 auto;
         min-width: 160px;
         font-size: 0.75rem;
         padding: 0.4rem 0.55rem;
@@ -8531,6 +8582,16 @@ html, body {
 }
 
 @media (max-width: 600px) {
+    .host-game-finished-banner {
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 0.5rem 1rem;
+    }
+
+    .host-finished-text {
+        font-size: 0.95rem;
+    }
+
     .host-dashboard .game-header {
         padding: 0.4rem 0.6rem;
     }

--- a/Server/Services/GameEngine.cs
+++ b/Server/Services/GameEngine.cs
@@ -3704,13 +3704,30 @@ public class GameEngine
             {
                 var nw = s.NetWorth;
                 var breakdown = new Dictionary<string, decimal>();
+
+                // Break down Portfolio into individual asset types
+                decimal stocksValue = 0, indexValue = 0, goldValue = 0, cryptoValue = 0;
+                foreach (var p in s.Portfolio.Values)
+                {
+                    switch (p.AssetType)
+                    {
+                        case "saham": stocksValue += p.TotalValue; break;
+                        case "reksadana": indexValue += p.TotalValue; break;
+                        case "emas": goldValue += p.TotalValue; break;
+                        case "crypto": cryptoValue += p.TotalValue; break;
+                    }
+                }
+
                 if (nw > 0)
                 {
                     if (s.CashBalance > 0) breakdown["Cash"] = Math.Round((s.CashBalance / nw) * 100, 1);
                     if (s.TotalSavingsValue > 0) breakdown["Savings"] = Math.Round((s.TotalSavingsValue / nw) * 100, 1);
                     if (s.TotalDepositoValue > 0) breakdown["Deposito"] = Math.Round((s.TotalDepositoValue / nw) * 100, 1);
                     if (s.TotalBondValue > 0) breakdown["Bond"] = Math.Round((s.TotalBondValue / nw) * 100, 1);
-                    if (s.TotalPortfolioValue > 0) breakdown["Portfolio"] = Math.Round((s.TotalPortfolioValue / nw) * 100, 1);
+                    if (stocksValue > 0) breakdown["Stocks"] = Math.Round((stocksValue / nw) * 100, 1);
+                    if (indexValue > 0) breakdown["Index"] = Math.Round((indexValue / nw) * 100, 1);
+                    if (goldValue > 0) breakdown["Gold"] = Math.Round((goldValue / nw) * 100, 1);
+                    if (cryptoValue > 0) breakdown["Crypto"] = Math.Round((cryptoValue / nw) * 100, 1);
                     if (s.TotalCrowdfundingValue > 0) breakdown["Crowdfunding"] = Math.Round((s.TotalCrowdfundingValue / nw) * 100, 1);
                 }
                 var initialCapital = 5_000_000m + (s.CurrentYear - 1) * GameSession.YEARLY_INCOME;
@@ -3723,7 +3740,14 @@ public class GameEngine
                     CurrentYear = s.CurrentYear,
                     CurrentMonth = s.CurrentMonth,
                     PortfolioBreakdown = breakdown,
-                    TotalGainLoss = nw - initialCapital
+                    TotalGainLoss = nw - initialCapital,
+                    SavingsInterestEarned = s.TotalSavingsInterestEarned,
+                    DepositoInterestEarned = s.TotalDepositoInterestEarned + s.Depositos.Sum(d => d.CurrentValue - d.Principal),
+                    BondCouponEarned = s.TotalBondCouponEarned,
+                    DividendEarned = s.TotalDividendEarned,
+                    PortfolioGainLoss = s.TotalRealizedPortfolioGainLoss + s.Portfolio.Values.Sum(p => p.ProfitLoss),
+                    CrowdfundingGainLoss = s.TotalRealizedCrowdfundingGainLoss + s.CrowdfundingInvestments.Where(c => !c.HasFailed).Sum(c => c.CurrentValue - c.InvestedAmount),
+                    TotalEventCostPaid = s.PlayerTotalEventCostPaid
                 };
             }).ToList();
         }

--- a/Shared/Models/PortfolioItem.cs
+++ b/Shared/Models/PortfolioItem.cs
@@ -261,6 +261,15 @@ public class PlayerSummary
     public int CurrentMonth { get; set; }
     public Dictionary<string, decimal> PortfolioBreakdown { get; set; } = new();  // % per asset type
     public decimal TotalGainLoss { get; set; }
+
+    // Financial details for host dashboard
+    public decimal SavingsInterestEarned { get; set; }
+    public decimal DepositoInterestEarned { get; set; }
+    public decimal BondCouponEarned { get; set; }
+    public decimal DividendEarned { get; set; }
+    public decimal PortfolioGainLoss { get; set; }
+    public decimal CrowdfundingGainLoss { get; set; }
+    public decimal TotalEventCostPaid { get; set; }
 }
 
 public class LeaderboardEntry


### PR DESCRIPTION
## Summary
- **Detailed portfolio cards**: Host dashboard now shows each player's portfolio breakdown with pie charts, financial details (cash, savings, deposits, bonds, mutual funds, stocks, gold, crypto, crowdfunding), and profit/loss indicators
- **Fix pie chart blipping**: Debounce chart re-renders using data hash comparison — charts only redraw when portfolio data actually changes, eliminating constant flickering
- **Fix text overlapping**: Constrain pie chart container to max-width 55%, add overflow handling to financial details section to prevent text overlap in narrow host cards
- **Game-ended indicator**: Show a prominent banner ("Permainan Selesai!") on host dashboard when all players finish, change leaderboard title to "Peringkat Akhir", hide the unlock-ready-status section
- **Leaderboard layout**: Restructure leaderboard entries from flex to CSS Grid for better name display and prevent rank/name/worth from colliding

## Files changed
- `Client/Pages/Game.razor` — Host dashboard UI, pie chart debouncing logic, game-finished state handling
- `Client/wwwroot/css/app.css` — Host card styles, game-finished banner, leaderboard grid layout, responsive fixes
- `Server/Services/GameEngine.cs` — Portfolio breakdown data for host view
- `Shared/Models/PortfolioItem.cs` — PortfolioBreakdown model

## Test plan
- [ ] Create a multiplayer room as host, join with 2+ players
- [ ] Verify host dashboard shows portfolio cards with pie charts and financial details
- [ ] Verify pie charts do NOT flicker/blink during gameplay or after game ends
- [ ] Verify no text overlapping in host portfolio cards at various screen sizes
- [ ] Play through to Year 15 — verify game-finished banner appears on host view
- [ ] Verify leaderboard title changes to "Peringkat Akhir" when game ends
- [ ] Verify "Status Siap Lanjut" section is hidden after game finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)